### PR TITLE
Websocket-based CS:GO streaming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ torch==2.4.1
 torcheval==0.0.7
 tqdm==4.66.4
 wandb==0.17.0
+websockets==15.0.1

--- a/src/web/web_game.py
+++ b/src/web/web_game.py
@@ -4,8 +4,12 @@ import json
 from pathlib import Path
 from typing import Tuple, Union
 
+import asyncio
+from threading import Thread
+
+import websockets
 from PIL import Image
-from flask import Flask, Response, request, send_from_directory
+from flask import Flask, request, send_from_directory
 
 from csgo.action_processing import CSGOAction
 from game.play_env import PlayEnv
@@ -50,6 +54,7 @@ class WebGame:
         web_path = Path(__file__).resolve().parent.parent.parent / "web"
         self.app = Flask(__name__, static_folder=str(web_path), static_url_path="")
         self._setup_routes()
+        self.clients = set()
 
     def encode_obs(self, obs) -> bytes:
         assert obs.ndim == 4 and obs.size(0) == 1
@@ -65,19 +70,6 @@ class WebGame:
         @app.route("/")
         def index():
             return send_from_directory(app.static_folder, "index.html")
-
-        @app.route("/frame")
-        def frame():
-            action = CSGOAction(list(self.keys_pressed), self.mouse_x, self.mouse_y, self.l_click, self.r_click)
-            next_obs, _, end, trunc, _ = self.env.step(action)
-            if end or trunc:
-                next_obs, _ = self.env.reset()
-            self.obs = next_obs
-            img = self.encode_obs(self.obs)
-            # reset mouse deltas after applying
-            self.mouse_x = 0
-            self.mouse_y = 0
-            return Response(img, mimetype="image/jpeg")
 
         @app.route("/event", methods=["POST"])
         def event():
@@ -111,7 +103,69 @@ class WebGame:
                 self.mouse_x = self.mouse_y = 0
             return "", 204
 
+    async def _handle_ws(self, websocket):
+        self.clients.add(websocket)
+        try:
+            async for message in websocket:
+                data = json.loads(message)
+                etype = data.get("type")
+                if etype == "key_down":
+                    key = JS_TO_KEY.get(data.get("code"))
+                    if key:
+                        self.keys_pressed.add(key)
+                elif etype == "key_up":
+                    key = JS_TO_KEY.get(data.get("code"))
+                    if key and key in self.keys_pressed:
+                        self.keys_pressed.remove(key)
+                elif etype == "mouse_move":
+                    self.mouse_x = data.get("dx", 0) * self.mouse_multiplier
+                    self.mouse_y = data.get("dy", 0) * self.mouse_multiplier
+                elif etype == "mouse_down":
+                    if data.get("button") == 0:
+                        self.l_click = True
+                    if data.get("button") == 2:
+                        self.r_click = True
+                elif etype == "mouse_up":
+                    if data.get("button") == 0:
+                        self.l_click = False
+                    if data.get("button") == 2:
+                        self.r_click = False
+                elif etype == "reset":
+                    self.obs, _ = self.env.reset()
+                    self.keys_pressed.clear()
+                    self.l_click = self.r_click = False
+                    self.mouse_x = self.mouse_y = 0
+        except websockets.ConnectionClosed:
+            pass
+        finally:
+            self.clients.discard(websocket)
+
+    async def _frame_loop(self):
+        delay = 1 / self.fps
+        while True:
+            action = CSGOAction(list(self.keys_pressed), self.mouse_x, self.mouse_y, self.l_click, self.r_click)
+            next_obs, _, end, trunc, _ = self.env.step(action)
+            if end or trunc:
+                next_obs, _ = self.env.reset()
+            self.obs = next_obs
+            img = self.encode_obs(self.obs)
+            self.mouse_x = 0
+            self.mouse_y = 0
+            for ws in list(self.clients):
+                try:
+                    await ws.send(img)
+                except websockets.ConnectionClosed:
+                    self.clients.discard(ws)
+            await asyncio.sleep(delay)
+
     def run(self) -> None:
         self.env.print_controls()
-        self.app.run(host=self.host, port=self.port + 1, threaded=True)
+        thread = Thread(target=self.app.run, kwargs={"host": self.host, "port": self.port + 1, "threaded": True}, daemon=True)
+        thread.start()
+
+        async def main():
+            async with websockets.serve(self._handle_ws, self.host, self.port, max_size=None):
+                await self._frame_loop()
+
+        asyncio.run(main())
 

--- a/web/index.html
+++ b/web/index.html
@@ -6,35 +6,56 @@
   <style>
     body { margin: 0; overflow: hidden; }
     canvas { width: 100vw; height: 100vh; display: block; }
+    #controls { position: absolute; bottom: 20px; left: 20px; pointer-events: none; }
+    .row { display: flex; justify-content: center; }
+    .key { width: 40px; height: 40px; border: 1px solid #fff; color: #fff; background: rgba(0,0,0,0.5); margin: 2px; display: flex; align-items: center; justify-content: center; font-family: sans-serif; }
+    .active { background: yellow; color: #000; }
   </style>
 </head>
 <body>
   <canvas id="screen"></canvas>
+  <div id="controls">
+    <div class="row"><div id="key-w" class="key">W</div></div>
+    <div class="row">
+      <div id="key-a" class="key">A</div>
+      <div id="key-s" class="key">S</div>
+      <div id="key-d" class="key">D</div>
+    </div>
+  </div>
   <script>
     const canvas = document.getElementById('screen');
     const ctx = canvas.getContext('2d');
     function resize() { canvas.width = window.innerWidth; canvas.height = window.innerHeight; }
     window.addEventListener('resize', resize); resize();
 
-    async function fetchFrame() {
-      const res = await fetch('frame');
-      const blob = await res.blob();
+    const wsPort = parseInt(location.port) - 1;
+    const wsProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${wsProtocol}://${location.hostname}:${wsPort}`);
+    ws.binaryType = 'blob';
+
+    const keyEls = {
+      'KeyW': document.getElementById('key-w'),
+      'KeyA': document.getElementById('key-a'),
+      'KeyS': document.getElementById('key-s'),
+      'KeyD': document.getElementById('key-d')
+    };
+    function highlight(code, on) {
+      const el = keyEls[code];
+      if (el) el.classList.toggle('active', on);
+    }
+
+    ws.onmessage = async (event) => {
+      const blob = event.data;
       const img = await createImageBitmap(blob);
       ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-      requestAnimationFrame(fetchFrame);
-    }
-    fetchFrame();
+    };
 
     function send(type, data) {
-      fetch('event', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({type, ...data})
-      }).catch(() => {});
+      ws.send(JSON.stringify({type, ...data}));
     }
 
-    document.addEventListener('keydown', (e) => { e.preventDefault(); send('key_down', {code: e.code}); });
-    document.addEventListener('keyup', (e) => { e.preventDefault(); send('key_up', {code: e.code}); });
+    document.addEventListener('keydown', (e) => { e.preventDefault(); highlight(e.code, true); send('key_down', {code: e.code}); });
+    document.addEventListener('keyup', (e) => { e.preventDefault(); highlight(e.code, false); send('key_up', {code: e.code}); });
     document.addEventListener('mousemove', (e) => { e.preventDefault(); send('mouse_move', {dx: e.movementX, dy: e.movementY}); });
     document.addEventListener('mousedown', (e) => { e.preventDefault(); send('mouse_down', {button: e.button}); });
     document.addEventListener('mouseup', (e) => { e.preventDefault(); send('mouse_up', {button: e.button}); });


### PR DESCRIPTION
## Summary
- stream CS:GO frames with a websocket server instead of HTTP polling
- add on-screen WASD buttons with highlighting
- update requirements with `websockets`

## Testing
- `python -m py_compile src/web/web_game.py`
- `python src/web_play.py --help` *(fails: ModuleNotFoundError: No module named 'huggingface_hub')*

------
https://chatgpt.com/codex/tasks/task_e_68404d87286483308f48c6332f2256df